### PR TITLE
fix: End of map vote not appearing & duplicate vote messages

### DIFF
--- a/src/Helpers/ChangeMapManager.cs
+++ b/src/Helpers/ChangeMapManager.cs
@@ -41,10 +41,12 @@ public class ChangeMapManager
     {
         if (string.IsNullOrEmpty(_state.NextMap)) return;
 
+        var mapName = _state.NextMap;
+        _state.NextMap = null;
         _state.MapChangeScheduled = false;
         _state.ChangeMapImmediately = true;
 
-        var map = _mapLister.Maps.FirstOrDefault(m => m.Name.Equals(_state.NextMap, StringComparison.OrdinalIgnoreCase));
+        var map = _mapLister.Maps.FirstOrDefault(m => m.Name.Equals(mapName, StringComparison.OrdinalIgnoreCase));
         if (map == null) return;
 
         int delay = _state.IsRtv ? _config.Rtv.ChangeMapDelay : _config.EndOfMap.ChangeMapDelay;

--- a/src/Helpers/EndOfMapVoteManager.cs
+++ b/src/Helpers/EndOfMapVoteManager.cs
@@ -228,6 +228,7 @@ public class EndOfMapVoteManager
             return;
         }
 
+        RefreshVoteMenu();
         _core.Scheduler.DelayBySeconds(1, () => RunVoteTimer(sessionId));
     }
 
@@ -326,12 +327,15 @@ public class EndOfMapVoteManager
 
         var localizer = _core.Translation.GetPlayerLocalizer(player);
         string displayName = map == "map_chooser.extend_option" ? localizer["map_chooser.extend_option"] : map;
-        player.SendChat(localizer["map_chooser.prefix"] + " " + localizer["map_chooser.vote.you_voted", displayName]);
 
         if (_config.AnnounceVotes)
         {
             int mapVoteCount = _votes.GetValueOrDefault(map, 0);
             _core.PlayerManager.SendChat(_core.Localizer["map_chooser.prefix"] + " " + _core.Localizer["map_chooser.vote.player_voted", player.Controller?.PlayerName ?? "Unknown", displayName, mapVoteCount]);
+        }
+        else
+        {
+            player.SendChat(localizer["map_chooser.prefix"] + " " + localizer["map_chooser.vote.you_voted", displayName]);
         }
         
         var currentMenu = _core.MenusAPI.GetCurrentMenu(player);

--- a/src/MapChooser.cs
+++ b/src/MapChooser.cs
@@ -13,7 +13,7 @@ using SwiftlyS2.Shared.SchemaDefinitions;
 
 namespace MapChooser;
 
-[PluginMetadata(Id = "MapChooser", Version = "1.0.8", Name = "Map Chooser", Author = "aga", Description = "Map chooser plugin for SwiftlyS2")]
+[PluginMetadata(Id = "MapChooser", Version = "1.1.0", Name = "Map Chooser", Author = "aga", Description = "Map chooser plugin for SwiftlyS2")]
 public sealed class MapChooser : BasePlugin {
     private MapChooserConfig _config = new();
     private MapsConfig _mapsConfig = new();
@@ -108,6 +108,7 @@ public sealed class MapChooser : BasePlugin {
         Core.GameEvent.HookPost<EventRoundAnnounceWarmup>(OnAnnounceWarmup);
         Core.GameEvent.HookPost<EventWarmupEnd>(OnWarmupEnd);
         Core.GameEvent.HookPost<EventCsWinPanelMatch>(OnWinPanelMatch);
+        Core.GameEvent.HookPost<EventGamePhaseChanged>(OnGamePhaseChanged);
         Core.GameEvent.HookPost<EventRoundAnnounceMatchStart>(OnMatchStart);
         Core.GameEvent.HookPost<EventRoundAnnounceMatchPoint>(OnMatchPoint);
         Core.Event.OnMapLoad += OnMapLoad;
@@ -120,6 +121,8 @@ public sealed class MapChooser : BasePlugin {
 
     private void OnMapLoad(IOnMapLoadEvent @event)
     {
+        if (string.IsNullOrEmpty(@event.MapName)) return;
+
         _eofManager?.ResetVote();
         _state.MapChangeScheduled = false;
         _state.EofVoteHappening = false;
@@ -149,8 +152,6 @@ public sealed class MapChooser : BasePlugin {
 
     private HookResult OnRoundStart(EventRoundStart @event)
     {
-        var warmupConVar = Core.ConVar.Find<int>("mp_warmup_period");
-        _state.WarmupRunning = warmupConVar?.Value == 1;
         CheckAutomatedVote();
         return HookResult.Continue;
     }
@@ -215,6 +216,19 @@ public sealed class MapChooser : BasePlugin {
         return HookResult.Continue;
     }
 
+    private HookResult OnGamePhaseChanged(EventGamePhaseChanged @event)
+    {
+        if (@event.NewPhase != (short)GamePhase.GAMEPHASE_MATCH_ENDED) return HookResult.Continue;
+        if (_state.MatchEnded) return HookResult.Continue;
+
+        _state.MatchEnded = true;
+        if (_state.EofVoteHappening)
+            _eofManager.ForceEnd();
+        else if (_state.MapChangeScheduled)
+            _changeMapManager.ChangeMap();
+        return HookResult.Continue;
+    }
+
     private HookResult OnRoundEnd(EventRoundEnd @event)
     {
         _state.RoundsPlayed++;
@@ -222,7 +236,7 @@ public sealed class MapChooser : BasePlugin {
         {
             _changeMapManager.ChangeMap();
         }
-        else if (!_state.MapChangeScheduled && !_state.ChangeMapImmediately)
+        else if (!_state.MapChangeScheduled)
         {
             CheckAutomatedVote();
         }
@@ -232,7 +246,7 @@ public sealed class MapChooser : BasePlugin {
 
     private void CheckAutomatedVote(bool force = false)
     {
-        if (!_config.EndOfMap.Enabled || _state.EofVoteHappening || _state.MapChangeScheduled || _state.ChangeMapImmediately || _state.WarmupRunning) return;
+        if (!_config.EndOfMap.Enabled || _state.EofVoteHappening || _state.MapChangeScheduled || _state.WarmupRunning) return;
 
         if (Core.Game.MatchData.Phase == GamePhase.GAMEPHASE_HALFTIME) return;
 


### PR DESCRIPTION
### Bug Fixes

- **Fix vote menu never showing** — `OnRoundStart` was reading `mp_warmup_period` (a config convar, not runtime state) and overwriting `WarmupRunning = true` every round, which permanently blocked `CheckAutomatedVote()` from triggering the end-of-map vote.
- **Fix vote menu not refreshing** — `RunVoteTimer()` never called `RefreshVoteMenu()`, so players who joined mid-vote or had their menu closed never saw it. The vote would end with 0 votes silently.
- **Fix `ChangeMapImmediately` blocking future votes** — `ChangeMap()` sets this flag to `true` but clears `MapChangeScheduled`. If the map change failed, this flag stayed stuck and blocked all future automated votes and round-end checks.
- **Fix duplicate vote messages** (#17) — When `AnnounceVotes` is enabled, the voter received both a personal "you voted" message and a global broadcast. Now only one message is sent.

### Closes

- #16 (NO ENDOFMAPVOTE)
- #17 (Double Messages)