### PR TITLE
fix: Improved edge-case handling, stability and added new variable to disable exiting map vote menu without selecting an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ MapChooser is a map voting plugin for SwiftlyS2. It handles Rock The Vote (RTV),
 | `MinPlayers` | `0` | Minimum number of players required to enable RTV. |
 | `MinRounds` | `0` | Minimum rounds that must be played before RTV is allowed. |
 | `ChangeMapImmediately` | `true` | Change the map immediately after a successful RTV vote. |
-| `ChangeMapDelay` | `3` | Delay in seconds before changing the map after a successful RTV vote. |
+| `ChangeMapDelay` | `3` | Delay in seconds before changing the map after a successful RTV vote (used when `ChangeMapImmediately` is `false`). |
 | `MapsToShow` | `6` | Number of maps to display in the RTV vote menu. |
 | `VoteDuration` | `30` | How long the vote menu remains open (seconds). |
 | `VotePercentage` | `60` | Percentage of players required to trigger the vote. |
@@ -83,16 +83,27 @@ MapChooser is a map voting plugin for SwiftlyS2. It handles Rock The Vote (RTV),
 | `MinRounds` | `0` | Minimum rounds required before `!extend` can be used. |
 | `VotePercentage` | `60` | Percentage of players required to pass the extend vote. |
 
+### Cycle Settings (`Cycle`)
+| Setting | Default | Description |
+| :--- | :--- | :--- |
+| `Enabled` | `false` | Enable automatic advance to the next map in the cycle when a match ends without an end-of-map vote. Disabled by default. |
+| `RandomOrder` | `false` | Pick the next map randomly from the cycle (excluding maps in cooldown) instead of following the configured order. |
+| `AddMapPermission` | `admin.changemap` | Permission flag required for `!addmap`. |
+| `RemoveMapPermission` | `admin.changemap` | Permission flag required for `!removemap`. |
+| `CycleMenuPermission` | `admin.changemap` | Permission flag required for `!cyclemenu` / `!mapcycle`. |
+
 ### Global Settings
 | Setting | Default | Description |
 | :--- | :--- | :--- |
 | `MapsInCooldown` | `3` | Number of recently played maps to exclude from the next vote. |
 | `AllowSpectatorsToVote` | `false` | Allow spectators to participate in votes. |
 | `AnnounceVotes` | `true` | Broadcast vote counts to all players during voting. |
+| `DisableVoteMenuExit` | `false` | When `true`, removes the “Exit” entry from vote menus so players must pick a map. |
+| `DetailedLogging` | `false` | Verbose logging for vote flow and map cycle decisions. |
 | `SetNextMapPermission` | `admin.changemap` | Permission flag required for the `!setnextmap` command. |
 | `MapsVotePermission` | `admin.mapsvote` | Permission flag required for the `!mapsvote` command. |
 | `ChangeMapPermission` | `admin.changemap` | Permission flag required for the `!map` / `!setmap` command. |
-| `Maps` | (List) | List of maps available. Use `ws:ID` for workshop maps. |
+| `Maps` | (List) | List of maps available. Workshop maps accept either a bare numeric ID (e.g. `3124567099`) or the explicit `ws:` prefix (e.g. `ws:3124567099`). |
 
 ### Commands Settings (`Commands`)
 
@@ -112,6 +123,9 @@ All command aliases are fully configurable. Each setting accepts a comma-separat
 | `MapsVote` | `mapsvote` | Aliases for the admin maps vote command. |
 | `ChangeMap` | `map,setmap` | Aliases for the admin change map command. |
 | `MapList` | `maplist,maps` | Aliases for the map list command. |
+| `AddMap` | `addmap` | Aliases for the add-map admin command. |
+| `RemoveMap` | `removemap` | Aliases for the remove-map admin command. |
+| `CycleMenu` | `cyclemenu,mapcycle` | Aliases for the cycle management menu command. |
 
 ### Map Configuration
 
@@ -162,7 +176,7 @@ In this example, when there are 1–3 real players on the server, only `Mirage` 
 
 ## Map Cycle
 
-When a match ends and no end-of-map vote fires, the plugin automatically advances to the next map in the cycle. The cycle order follows `maps.jsonc`. Use `!cyclemenu` to view the order, move maps up/down, or remove them in-game. Use `!addmap` / `!removemap` to manage the list from chat — changes persist to disk immediately.
+When a match ends and no end-of-map vote fires, the plugin can automatically advance to the next map in the cycle. This is controlled by `Cycle.Enabled` and is **disabled by default** — enable it explicitly if you want the rotation. The cycle order follows `maps.jsonc` by default; set `Cycle.RandomOrder` to `true` to pick the next map at random from the cycle instead. Maps in cooldown are skipped either way. Use `!cyclemenu` to view the order, move maps up/down, or remove them in-game. Use `!addmap` / `!removemap` to manage the list from chat — changes persist to disk immediately.
 
 ## Features
 

--- a/resources/templates/config.jsonc
+++ b/resources/templates/config.jsonc
@@ -62,6 +62,8 @@
             "CycleMenuPermission": "admin.changemap"
         },
         "AllowSpectatorsToVote": false,
+        "DisableVoteMenuExit": false,
+        "DetailedLogging": false,
         "SetNextMapPermission": "admin.changemap",
         "MapsVotePermission": "admin.mapsvote"
     }

--- a/src/Commands/TimeleftCommand.cs
+++ b/src/Commands/TimeleftCommand.cs
@@ -46,7 +46,8 @@ public class TimeleftCommand
 
         if (timelimit > 0)
         {
-            float timePlayed = _core.Engine.GlobalVars.CurrentTime - _state.MapStartTime;
+            float currentTime = _core.TryGetCurrentTime();
+            float timePlayed = currentTime - _state.MapStartTime;
             float timeRemaining = (timelimit * 60) - timePlayed;
 
             if (timeRemaining > 1)

--- a/src/Dependencies/PluginState.cs
+++ b/src/Dependencies/PluginState.cs
@@ -10,6 +10,13 @@ public class PluginState
     public string? NextMap { get; set; }
     public bool ChangeMapImmediately { get; set; }
     public bool IsRtv { get; set; }
+    /// <summary>
+    /// True when a map change has been scheduled and is waiting for the next
+    /// EventRoundEnd to fire the actual change. Independent of <see cref="IsRtv"/>
+    /// so it survives state resets that clear IsRtv (e.g. ChangeMap, OnMatchStart).
+    /// Cleared by ChangeMap, OnMapLoad and OnMatchStart.
+    /// </summary>
+    public bool QueuedRoundEndChange { get; set; }
     public float MapStartTime { get; set; }
     public int RoundsPlayed { get; set; }
     public bool WarmupRunning { get; set; }
@@ -19,5 +26,12 @@ public class PluginState
     public DateTime? RtvCooldownEndTime { get; set; }
     public bool MatchEnded { get; set; }
     public bool EofVoteCompleted { get; set; }
+    /// <summary>
+    /// True once a `changelevel`/`host_workshop_map` command has actually been queued.
+    /// Used to debounce reentrant `ChangeMap()` calls from concurrent end‑of‑match
+    /// event sources (WinPanelMatch / GamePhaseChanged / RoundEnd / cycle trigger).
+    /// Cleared in OnMapLoad.
+    /// </summary>
+    public bool MapSwitchInFlight { get; set; }
     public Dictionary<int, string> Nominations { get; set; } = new();
 }

--- a/src/Helpers/ChangeMapManager.cs
+++ b/src/Helpers/ChangeMapManager.cs
@@ -1,6 +1,7 @@
 using MapChooser.Models;
 using MapChooser.Dependencies;
 using MapChooser.Helpers;
+using Microsoft.Extensions.Logging;
 using SwiftlyS2.Shared;
 
 namespace MapChooser.Helpers;
@@ -11,6 +12,7 @@ public class ChangeMapManager
     private readonly PluginState _state;
     private readonly MapLister _mapLister;
     private readonly MapChooserConfig _config;
+    private CancellationTokenSource? _pendingChange;
 
     public ChangeMapManager(ISwiftlyCore core, PluginState state, MapLister mapLister, MapChooserConfig config)
     {
@@ -27,7 +29,19 @@ public class ChangeMapManager
         _state.ChangeMapImmediately = changeImmediately;
         _state.IsRtv = isRtv;
 
-        if (changeImmediately || _state.MatchEnded)
+        bool fireNow = changeImmediately || _state.MatchEnded;
+        // Round-end queueing only applies to RTV. Non-RTV votes (end-of-map,
+        // admin maps vote, votemap) that aren't immediate wait for the match
+        // to end naturally and are then triggered by OnWinPanelMatch /
+        // OnGamePhaseChanged.
+        _state.QueuedRoundEndChange = !fireNow && isRtv;
+
+        if (_config.DetailedLogging)
+            _core.Logger.LogInformation(
+                "MapChooser: ScheduleMapChange map={Map} immediate={Immediate} isRtv={IsRtv} matchEnded={MatchEnded} -> {Action}",
+                mapName, changeImmediately, isRtv, _state.MatchEnded, fireNow ? "ChangeMap" : "QueuedRoundEnd");
+
+        if (fireNow)
         {
             ChangeMap();
         }
@@ -39,32 +53,75 @@ public class ChangeMapManager
 
     public void ChangeMap()
     {
-        if (string.IsNullOrEmpty(_state.NextMap)) return;
+        // Debounce concurrent triggers (WinPanelMatch + GamePhaseChanged + cycle, etc.)
+        if (_state.MapSwitchInFlight) return;
+        if (string.IsNullOrEmpty(_state.NextMap))
+        {
+            if (_config.DetailedLogging)
+                _core.Logger.LogInformation("MapChooser: ChangeMap aborted — NextMap is empty.");
+            return;
+        }
 
         var mapName = _state.NextMap;
         _state.NextMap = null;
         _state.MapChangeScheduled = false;
         _state.ChangeMapImmediately = true;
+        _state.QueuedRoundEndChange = false;
 
         var map = _mapLister.Maps.FirstOrDefault(m => m.Name.Equals(mapName, StringComparison.OrdinalIgnoreCase));
-        if (map == null) return;
+        if (map == null)
+        {
+            _core.Logger.LogWarning("MapChooser: ChangeMap aborted — map '{Map}' not found in map list.", mapName);
+            return;
+        }
 
         int delay = _state.IsRtv ? _config.Rtv.ChangeMapDelay : _config.EndOfMap.ChangeMapDelay;
         _state.IsRtv = false;
+        _state.MapSwitchInFlight = true;
         _core.PlayerManager.SendChat(_core.Localizer["map_chooser.prefix"] + " " + _core.Localizer["map_chooser.changing_map", map.Name, delay]);
-        
-        _core.Scheduler.DelayBySeconds(delay, () => {
-            if (!string.IsNullOrEmpty(map.Id) && (map.Id.StartsWith("ws:") || long.TryParse(map.Id, out _)))
+
+        // Cancel any previously scheduled (but not yet fired) change to prevent stacking.
+        _pendingChange?.Cancel();
+
+        _pendingChange = _core.Scheduler.DelayBySeconds(delay, () =>
+        {
+            try
             {
-                string workshopId = map.Id.StartsWith("ws:") ? map.Id.Substring(3) : map.Id;
-                _core.Engine.ExecuteCommandWithBuffer($"nextlevel {map.Name}", _ => { });
-                _core.Engine.ExecuteCommandWithBuffer($"host_workshop_map {workshopId}", _ => { });
+                if (_core.Engine is not { } engine) return;
+
+                if (!string.IsNullOrEmpty(map.Id) && (map.Id.StartsWith("ws:") || long.TryParse(map.Id, out _)))
+                {
+                    string workshopId = map.Id.StartsWith("ws:") ? map.Id.Substring(3) : map.Id;
+                    engine.ExecuteCommandWithBuffer($"nextlevel {map.Name}", _ => { });
+                    engine.ExecuteCommandWithBuffer($"host_workshop_map {workshopId}", _ => { });
+                }
+                else
+                {
+                    engine.ExecuteCommandWithBuffer($"nextlevel {map.Name}", _ => { });
+                    engine.ExecuteCommandWithBuffer($"changelevel {map.Id ?? map.Name}", _ => { });
+                }
             }
-            else
+            catch (Exception ex)
             {
-                _core.Engine.ExecuteCommandWithBuffer($"nextlevel {map.Name}", _ => { });
-                _core.Engine.ExecuteCommandWithBuffer($"changelevel {map.Id ?? map.Name}", _ => { });
+                _core.Logger.LogError(ex, "MapChooser: failed to issue map change to {Map}", map.Name);
+                // Clear in-flight so a retry/fallback path can run.
+                _state.MapSwitchInFlight = false;
+            }
+            finally
+            {
+                _pendingChange = null;
             }
         });
+
+        // Belt & braces: if the map actually changes for any other reason before
+        // the delay fires, the scheduler will auto-cancel this token.
+        _core.Scheduler.StopOnMapChange(_pendingChange);
+    }
+
+    /// <summary>Cancel any pending map-change callback (used during plugin unload).</summary>
+    public void CancelPending()
+    {
+        _pendingChange?.Cancel();
+        _pendingChange = null;
     }
 }

--- a/src/Helpers/EndOfMapVoteManager.cs
+++ b/src/Helpers/EndOfMapVoteManager.cs
@@ -307,7 +307,7 @@ public class EndOfMapVoteManager
     {
         if (!_voteActive) return;
         var menu = new EndOfMapVoteMenu(_core, _mapCooldown);
-        var builtMenu = menu.Show(player, _mapsInVote, RegisterVote);
+        var builtMenu = menu.Show(player, _mapsInVote, RegisterVote, _config.DisableVoteMenuExit);
         _activeVoteMenus[player.Slot] = builtMenu;
     }
 

--- a/src/Helpers/EngineHelpers.cs
+++ b/src/Helpers/EngineHelpers.cs
@@ -1,0 +1,55 @@
+using SwiftlyS2.Shared;
+
+namespace MapChooser.Helpers;
+
+internal static class EngineHelpers
+{
+    /// <summary>Engine deref — call only from gameplay events or a Core.Scheduler.NextWorldUpdate callback (NOT from OnMapLoad/OnMapUnload).</summary>
+    public static bool TryGetEngineSnapshot(this ISwiftlyCore core, out string mapName, out string workshopId, out float currentTime)
+    {
+        mapName = string.Empty;
+        workshopId = string.Empty;
+        currentTime = 0f;
+
+        try
+        {
+            if (core.Engine is not { } engine) return false;
+            var gv = engine.GlobalVars;
+            mapName = gv.MapName.ToString() ?? string.Empty;
+            workshopId = engine.WorkshopId ?? string.Empty;
+            currentTime = gv.CurrentTime;
+            return true;
+        }
+        catch
+        {
+            mapName = string.Empty;
+            workshopId = string.Empty;
+            currentTime = 0f;
+            return false;
+        }
+    }
+
+    /// <summary>Engine deref — call only from gameplay events or a Core.Scheduler.NextWorldUpdate callback (NOT from OnMapLoad/OnMapUnload).</summary>
+    public static float TryGetCurrentTime(this ISwiftlyCore core)
+    {
+        try
+        {
+            if (core.Engine is { } engine)
+                return engine.GlobalVars.CurrentTime;
+        }
+        catch { }
+        return 0f;
+    }
+
+    /// <summary>Engine deref — call only from gameplay events or a Core.Scheduler.NextWorldUpdate callback (NOT from OnMapLoad/OnMapUnload).</summary>
+    public static string TryGetWorkshopId(this ISwiftlyCore core)
+    {
+        try
+        {
+            if (core.Engine is { } engine)
+                return engine.WorkshopId ?? string.Empty;
+        }
+        catch { }
+        return string.Empty;
+    }
+}

--- a/src/Helpers/MapCooldown.cs
+++ b/src/Helpers/MapCooldown.cs
@@ -44,11 +44,13 @@ public class MapCooldown
         // Find if this identity exists in history
         if (!_mapsOnCooldown.Contains(identity)) return false;
 
-        // Verify it's not the current map
-        if (_core.Engine == null) return false;
+        // Verify it's not the current map. During map transitions the engine
+        // pointer / GlobalVars / WorkshopId may all be null — bail safely.
+        if (!_core.TryGetEngineSnapshot(out var currentMapName, out var currentWorkshopId, out _))
+            return false;
 
-        var currentMapName = _core.Engine.GlobalVars.MapName.ToString().ToLower();
-        var currentWorkshopId = _core.Engine.WorkshopId.ToLower();
+        currentMapName = currentMapName.ToLower();
+        currentWorkshopId = currentWorkshopId.ToLower();
 
         if (identity == currentMapName || (!string.IsNullOrEmpty(currentWorkshopId) && identity == currentWorkshopId))
             return false;

--- a/src/MapChooser.cs
+++ b/src/MapChooser.cs
@@ -144,6 +144,7 @@ public sealed class MapChooser : BasePlugin
 
     private void OnMapLoad(IOnMapLoadEvent @event)
     {
+        if (@event.MapName == null) return;
         if (string.IsNullOrEmpty(@event.MapName)) return;
 
         _eofManager?.ResetVote();
@@ -228,6 +229,7 @@ public sealed class MapChooser : BasePlugin
         _state.EofVoteCompleted = false;
         _state.IsRtv = false;
         _state.ChangeMapImmediately = false;
+        _state.QueuedRoundEndChange = false;
         _state.NextMap = null;
         _state.ExtendsLeft = _config.EndOfMap.ExtendLimit;
 
@@ -281,8 +283,17 @@ public sealed class MapChooser : BasePlugin
     private HookResult OnRoundEnd(EventRoundEnd @event)
     {
         _state.RoundsPlayed++;
-        if (_state.MapChangeScheduled && !_state.EofVoteHappening && !_state.ChangeMapImmediately && _state.IsRtv)
+
+        if (_config.DetailedLogging)
+            Core.Logger.LogInformation(
+                "MapChooser: OnRoundEnd scheduled={Scheduled} queuedRoundEnd={Queued} eofVote={Eof} immediate={Immediate} isRtv={IsRtv} nextMap={NextMap}",
+                _state.MapChangeScheduled, _state.QueuedRoundEndChange, _state.EofVoteHappening,
+                _state.ChangeMapImmediately, _state.IsRtv, _state.NextMap ?? "<null>");
+
+        if (_state.QueuedRoundEndChange && _state.MapChangeScheduled && !_state.EofVoteHappening)
         {
+            if (_config.DetailedLogging)
+                Core.Logger.LogInformation("MapChooser: OnRoundEnd firing queued ChangeMap for '{Map}'.", _state.NextMap ?? "<null>");
             _changeMapManager.ChangeMap();
         }
         else if (!_state.MapChangeScheduled)
@@ -295,7 +306,20 @@ public sealed class MapChooser : BasePlugin
 
     private void CheckAutomatedVote(bool force = false)
     {
+        try
+        {
+            CheckAutomatedVoteCore(force);
+        }
+        catch (Exception ex)
+        {
+            Core.Logger.LogError(ex, "MapChooser: CheckAutomatedVote threw");
+        }
+    }
+
+    private void CheckAutomatedVoteCore(bool force)
+    {
         if (!_config.EndOfMap.Enabled || _state.EofVoteHappening || _state.MapChangeScheduled || _state.WarmupRunning) return;
+        if (_state.MapSwitchInFlight) return;
 
         // Silent early exit if game is not fully initialized yet (MapStartTime is set in OnWarmupEnd/OnMatchStart)
         // This prevents spamming logs with GameRules exceptions during early map load
@@ -357,14 +381,7 @@ public sealed class MapChooser : BasePlugin
 
         if (!trigger && winlimit > 0)
         {
-            var teams = Core.EntitySystem.GetAllEntitiesByClass<CCSTeam>();
-            int maxTeamScore = 0;
-            foreach (var team in teams)
-            {
-                int score = team.ScoreFirstHalf + team.ScoreSecondHalf + team.ScoreOvertime;
-                if (score > maxTeamScore) maxTeamScore = score;
-            }
-
+            int maxTeamScore = TryGetMaxTeamScore();
             if (winlimit - maxTeamScore <= _config.EndOfMap.TriggerRoundsBeforeEnd)
             {
                 trigger = true;
@@ -375,14 +392,7 @@ public sealed class MapChooser : BasePlugin
         if (!trigger && winlimit == 0 && maxrounds > 0)
         {
             int effectiveWinlimit = maxrounds / 2 + 1;
-            var teams = Core.EntitySystem.GetAllEntitiesByClass<CCSTeam>();
-            int maxTeamScore = 0;
-            foreach (var team in teams)
-            {
-                int score = team.ScoreFirstHalf + team.ScoreSecondHalf + team.ScoreOvertime;
-                if (score > maxTeamScore) maxTeamScore = score;
-            }
-
+            int maxTeamScore = TryGetMaxTeamScore();
             if (effectiveWinlimit - maxTeamScore <= _config.EndOfMap.TriggerRoundsBeforeEnd)
             {
                 trigger = true;
@@ -396,6 +406,31 @@ public sealed class MapChooser : BasePlugin
             if (Core.Engine != null)
                 _state.NextEofVotePossibleTime = Core.Engine.GlobalVars.CurrentTime + _config.EndOfMap.VoteDuration + 1;
             _eofManager.StartVote(_config.EndOfMap.VoteDuration, _config.EndOfMap.MapsToShow);
+        }
+    }
+
+    /// <summary>
+    /// Safely read the highest team score. The entity system can throw if it
+    /// isn't fully initialised yet (e.g. during early map load), so swallow
+    /// and return 0 in that case.
+    /// </summary>
+    private int TryGetMaxTeamScore()
+    {
+        try
+        {
+            var teams = Core.EntitySystem.GetAllEntitiesByClass<CCSTeam>();
+            int maxTeamScore = 0;
+            foreach (var team in teams)
+            {
+                int score = team.ScoreFirstHalf + team.ScoreSecondHalf + team.ScoreOvertime;
+                if (score > maxTeamScore) maxTeamScore = score;
+            }
+            return maxTeamScore;
+        }
+        catch (Exception ex)
+        {
+            Core.Logger.LogWarning(ex, "MapChooser: failed to read team scores");
+            return 0;
         }
     }
 
@@ -427,5 +462,27 @@ public sealed class MapChooser : BasePlugin
 
     public override void Unload()
     {
+        try
+        {
+            _checkVoteTimer?.Cancel();
+            _checkVoteTimer = null;
+
+            _changeMapManager?.CancelPending();
+
+            Core.Event.OnMapLoad -= OnMapLoad;
+
+            Core.GameEvent.UnhookPost<EventRoundEnd>();
+            Core.GameEvent.UnhookPost<EventRoundStart>();
+            Core.GameEvent.UnhookPost<EventRoundAnnounceWarmup>();
+            Core.GameEvent.UnhookPost<EventWarmupEnd>();
+            Core.GameEvent.UnhookPost<EventCsWinPanelMatch>();
+            Core.GameEvent.UnhookPost<EventGamePhaseChanged>();
+            Core.GameEvent.UnhookPost<EventRoundAnnounceMatchStart>();
+            Core.GameEvent.UnhookPost<EventRoundAnnounceMatchPoint>();
+        }
+        catch (Exception ex)
+        {
+            Core.Logger.LogError(ex, "MapChooser: Unload cleanup failed");
+        }
     }
 }

--- a/src/MapChooser.cs
+++ b/src/MapChooser.cs
@@ -16,7 +16,7 @@ using SwiftlyS2.Shared.SchemaDefinitions;
 
 namespace MapChooser;
 
-[PluginMetadata(Id = "MapChooser", Version = "1.2.4", Name = "Map Chooser", Author = "aga", Description = "Map chooser plugin for SwiftlyS2")]
+[PluginMetadata(Id = "MapChooser", Version = "1.3.0", Name = "Map Chooser", Author = "aga", Description = "Map chooser plugin for SwiftlyS2")]
 public sealed class MapChooser : BasePlugin
 {
     private MapChooserConfig _config = new();

--- a/src/Menu/AdminChangeMapMenu.cs
+++ b/src/Menu/AdminChangeMapMenu.cs
@@ -20,8 +20,6 @@ public class AdminChangeMapMenu
     public void Show(IPlayer player, Action<IPlayer, string> onChangeMap)
     {
         var localizer = _core.Translation.GetPlayerLocalizer(player);
-        var currentMapId = _core.Engine.GlobalVars.MapName.ToString();
-        var currentWorkshopId = _core.Engine.WorkshopId;
         var builder = _core.MenusAPI.CreateBuilder();
         builder.Design.SetMenuTitle(localizer["map_chooser.change_map.title"] ?? "Change map to:");
         foreach (var map in _mapLister.Maps)

--- a/src/Menu/EndOfMapVoteMenu.cs
+++ b/src/Menu/EndOfMapVoteMenu.cs
@@ -20,11 +20,15 @@ public class EndOfMapVoteMenu
         _mapCooldown = mapCooldown;
     }
 
-    public IMenuAPI Show(IPlayer player, List<string> mapsInVote, Action<IPlayer, string> onVote)
+    public IMenuAPI Show(IPlayer player, List<string> mapsInVote, Action<IPlayer, string> onVote, bool disableExit = false)
     {
         var localizer = _core.Translation.GetPlayerLocalizer(player);
         var builder = _core.MenusAPI.CreateBuilder();
         builder.Design.SetMenuTitle(localizer["map_chooser.vote.title"] ?? "Vote for the next map:");
+        if (disableExit)
+        {
+            builder.DisableExit();
+        }
         foreach (var map in mapsInVote)
         {
             string displayName = map;

--- a/src/Menu/NominateMenu.cs
+++ b/src/Menu/NominateMenu.cs
@@ -24,8 +24,7 @@ public class NominateMenu
     public void Show(IPlayer player, Action<IPlayer, string> onNominate)
     {
         var localizer = _core.Translation.GetPlayerLocalizer(player);
-        var currentMapId = _core.Engine.GlobalVars.MapName.ToString();
-        var currentWorkshopId = _core.Engine.WorkshopId;
+        _core.TryGetEngineSnapshot(out var currentMapId, out var currentWorkshopId, out _);
         var builder = _core.MenusAPI.CreateBuilder();
         builder.Design.SetMenuTitle(localizer["map_chooser.nominate.title"] ?? "Nominate a map:");
         var playerCount = _core.PlayerManager.GetAllPlayers()

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -85,6 +85,8 @@ public class MapChooserConfig
     public CommandsConfig Commands { get; set; } = new();
     public bool AllowSpectatorsToVote { get; set; } = false;
     public bool AnnounceVotes { get; set; } = true;
+    public bool DisableVoteMenuExit { get; set; } = false;
+    public bool DetailedLogging { get; set; } = false;
     public string SetNextMapPermission { get; set; } = "admin.changemap";
     public string MapsVotePermission { get; set; } = "admin.mapsvote";
     public string ChangeMapPermission { get; set; } = "admin.changemap";


### PR DESCRIPTION
### New Features

- **`DisableVoteMenuExit`** *(default `false`)*  
  Hides the Exit button from the end-of-map vote menu so players can't dismiss it without voting.

- **`DetailedLogging`** *(default `false`)*  
  Verbose logs for the whole map-rotation flow: vote scheduling, round-end queue decisions, map-change triggers, and aborted/skipped changes. For investigating misbehaving votes or map switches.

### Improvements

- **Full unload cleanup**  
  Plugin unload now cancels any scheduled map change, stops the periodic vote-check timer, and unhooks every game event. Previously, reloading mid-match left stale callbacks that re-fired on the next map.

- **Hardened automated vote check**  
  Early in a map the entity system isn't fully initialized and reading team scores can throw. The vote check now logs a warning and continues instead of taking the rotation logic down with it.

- **README sync**  
  Documents the two new global options, the previously-undocumented map-cycle settings (enable flag, random-order toggle, per-command permissions), the `addmap` / `removemap` / `cyclemenu` aliases, and the accepted workshop ID formats (bare numeric or `ws:` prefix).

### Bug fixes

- **Server crash during map transitions**  
  *Cause:* engine pointer and its globals (current map name, workshop ID, current time) can briefly be null while CS2 swaps maps; map cooldown lookups, the nominate menu, `!timeleft`, and the map-change executor read them unguarded.  
  *Fix:* all reads now safely no-op when the engine is unavailable.

- **Stacked `changelevel` commands at match end**  
  *Cause:* four event sources (match-end panel, game-phase change, round end, cycle trigger) each fired their own map change, queueing redundant level loads back-to-back.  
  *Fix:* map changes are debounced — first request wins, any pending one is cancelled if a different change takes over.

- **Non-RTV votes firing one round early**  
  *Cause:* round-end queue was keyed off a flag that gets cleared by normal state resets, so end-of-map vote / admin maps vote / `!votemap` results executed on the next round end instead of waiting for match end.  
  *Fix:* round-end queueing is now RTV-only; other vote types wait for the match to actually end.

- **Null-reference on map load**  
  Guarded against a missing map name in the map-load event.